### PR TITLE
Use the tag name for the version in npm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,5 +88,5 @@ jobs:
         # NOTE: Assumes tag in form x.y.z
         # TODO: figure out why ${{github.event.release.tag_name}} doesn't work
         run: |
-          yarn version "${GITHUB_REF:10}" --immediate
+          yarn version "${github.ref_name}" --immediate
           yarn npm publish --access public --tag latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: get env
-        run: echo "${{ toJson(github) }}"
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "${GITHUB_CONTEXT}"
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: get env
-        run: echo $GITHUB
+        run: echo "${{ toJson(github) }}"
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,12 @@ env:
   YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN_LIB_NPM }}
 
 jobs:
+  debug:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: get env
+        run: echo $GITHUB
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Assuming that a releases tag name is the version, using github.ref_name should give the string for the tag to the command to publish the artifacts to npm.

See https://docs.github.com/en/actions/learn-github-actions/contexts#github-context:~:text=branch%2D1.-,github,-.ref_name