### PR TITLE
Check yarn version and enable corepack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Check yarn version
         run: |
-          if [ `yarn --version` != `cat package.json | jq .packageManager -r | cut -c 6-` ]; then
+          if [ "`yarn --version`" != "`cat package.json | jq .packageManager -r | cut -c 6-`" ]; then
             echo "::warning file=package.json,title=YarnVersionMismatch::Yarn `yarn --version` does not match required version"
           else
             echo "::notice file=package.json,title=YarnVersionMatch::Yarn `yarn --version` matches required version"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,18 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      # This is required to confirm that GHA will use the right version of Yarn
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Check yarn version
+        run: |
+          if [ `yarn --version` != `cat package.json | jq .packageManager -r | cut -c 6-` ]; then
+            echo "::warning file=package.json,title=YarnVersionMismatch::Yarn `yarn --version` does not match required version"
+          else
+            echo "::notice file=package.json,title=YarnVersionMatch::Yarn `yarn --version` matches required version"
+          fi
+
       - name: Cache node modules
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
Without this, we cannot guarantee that we will build galc-ui with the correct version of Yarn. GitHub Actions Ubuntu images ship with [Yarn 1.22.22 by default][0].

[0]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md