### PR TITLE
AP-449: avoid leaking env variables into build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -44,6 +44,6 @@ export default defineConfig({
   },
   plugins: [vue(), stripDevCSS()],
   define: {
-    'process.env': process.env
+    'process.env.NODE_ENV': `"${process.env.NODE_ENV}"`
   }
 })


### PR DESCRIPTION
@yzhoubk reported in Slack that snapshot builds were failing again as in AP-403. upon further investigation, i discovered that vite was dumping our entire environment into the build, which could lead to credential leakage. this scopes to the only environment variable that's needed by vue's reactivity-related internals.